### PR TITLE
Only count paired-end overlaps once for depth

### DIFF
--- a/tools/Varpipeline.py
+++ b/tools/Varpipeline.py
@@ -266,7 +266,7 @@ class snp():
         samDir = self.outdir + "/SamTools"
         i = datetime.now()
 
-        self.__CallCommand(['samtools depth', samDir + '/coverage.txt'],['samtools','depth', '-a', self.__finalBam])
+        self.__CallCommand(['samtools depth', samDir + '/coverage.txt'],['samtools','depth', '-s', '-a', self.__finalBam])
         #self.__CallCommand(['bedtools coverage', samDir + '/bed_amp_coverage.txt' ],
                            #[self.__bedtools, 'coverage', '-abam', self.__finalBam, '-b', self.__bedlist_amp])
         #self.__CallCommand(['sort', samDir + '/bed_amp_sorted_coverage.txt' ],['sort', '-nk', '6', samDir + '/bed_amp_coverage.txt'])


### PR DESCRIPTION
Samtools `depth` now has the functionality to only count overlaps in paired-end reads once. The community seems to think this is a more correct calculation of depth: https://bioinformatics.stackexchange.com/questions/5427/double-counting-coverage-of-overlapped-read-pairs. This PR enables this capability.